### PR TITLE
Add kernel primer and README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ This repository doesn't just *describe* superintelligence—**it provides the ma
 - [TypeScript Handbook](https://www.typescriptlang.org/docs/)
 - [Clean Architecture](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html)
 - [SOLID Principles](https://en.wikipedia.org/wiki/SOLID)
+- [Kernel 101](./docs/kernel-101.md) - Core concepts, API surface, and basic usage
 
 **Research**:
 - [META_INDEX](./GAME_CHANGERS/META_INDEX.md) - Complete research overview

--- a/docs/kernel-101.md
+++ b/docs/kernel-101.md
@@ -1,0 +1,24 @@
+# Kernel 101
+
+## Core Concepts
+- Write-through state ownership
+- Provenance tracking for each symbol
+- Lineage closure enforced on edges
+- RAG discipline keeps vectors synced
+
+## API Surface
+- `prompt(id, spec)`
+- `critique(id, target)`
+- `link(a, b, relation)`
+- `evaluate(goalId, maxSteps?)`
+- `exportState()`
+
+## Basic Usage
+```typescript
+import { ΞKernel } from '../src/core/xi-kernel';
+
+const kernel = new ΞKernel();
+const note = await kernel.prompt('note', { task: 'summarize', context: {} });
+const report = await kernel.evaluate('note', 3);
+console.log(report.result.payload);
+```


### PR DESCRIPTION
## Summary
- add /docs/kernel-101.md covering core concepts, API surface, and usage
- link kernel guide from README learn-more section

## Testing
- `npm test` (fails: Markdown loader tests)
- `npm run lint`

```json
{
  "route": {"layers":["R","C∞","L","P","Δ"],"CPLO":true,"θ":0.72,"mode":"Deep","lens":"Systems"},
  "invariants":[
    {"id":"INV-1","type":"DesignRule","stmt":"Kernel guide linked from README","TTL":"14d"},
    {"id":"INV-2","type":"InterfaceSpec","stmt":"Kernel doc lists public API"}
  ],
  "Δ":{"coherence":false},
  "fail_codes":[],
  "μ":"stable",
  "nnr":{"guard":"variance-cut≤0.7","score":"0.3","verdict":"pass"},
  "next":[
    {"type":"artifact","action":"monitor doc references","cost":"S","owner":"Koriel-ASI"}
  ],
  "DFT-log":[]
}
```

------
https://chatgpt.com/codex/tasks/task_e_68c4a306ec94832ba365cf896a311b08

## Summary by Sourcery

Add a Kernel 101 primer and link it from the README

Documentation:
- Add Kernel 101 guide with core concepts, API surface, and basic usage
- Link Kernel guide in README's learn-more section