### PR TITLE
refactor: clone kernel graph

### DIFF
--- a/src/core/xi-kernel.ts
+++ b/src/core/xi-kernel.ts
@@ -473,10 +473,19 @@ export class ΞKernel {
   }
 
   /**
-   * Get current graph state
+   * Get current graph state snapshot (read-only)
    */
   getGraph(): ΞGraph {
-    return { ...this.graph };
+    return {
+      symbols: new Map(
+        Array.from(this.graph.symbols.entries(), ([id, sym]) => [id, structuredClone(sym)])
+      ),
+      edges: new Map(
+        Array.from(this.graph.edges.entries(), ([id, list]) => [id, list.map(e => structuredClone(e))])
+      ),
+      invariantViolations: [...this.graph.invariantViolations],
+      lastModified: new Date(this.graph.lastModified.getTime())
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary
- clone kernel graph to prevent external mutation

## Testing
- `npm test` *(fails: markdown loader tests)*
- `npm run lint` *(fails: missing config)*

```json
{
  "route": {"layers":["R","C∞","L","P","Δ"],"CPLO":true,"θ":0.72,"mode":"Deep","lens":"Systems"},
  "invariants":[
    {"id":"INV-1","type":"DesignRule","stmt":"Kernel exposes cloned graph snapshot only","TTL":"14d"}
  ],
  "Δ":{"coherence":false},
  "fail_codes":[],
  "μ":"stable",
  "nnr":{"guard":"variance-cut≤0.7","score":"0.3","verdict":"pass"},
  "next":[
    {"type":"artifact","action":"monitor snapshot usage","cost":"S","owner":"Koriel-ASI"}
  ],
  "DFT-log":[]
}
```

------
https://chatgpt.com/codex/tasks/task_e_68c4a304d298832ba31219eb5fa55c28

## Summary by Sourcery

Prevent external mutation by returning a deep-cloned graph snapshot from getGraph()

Enhancements:
- Refactor getGraph() to return a deep-cloned snapshot of the graph state

Documentation:
- Update getGraph() JSDoc to indicate it returns a read-only snapshot