### PR TITLE
feat: stub anthropic extended operations

### DIFF
--- a/src/core/llm-providers/anthropic-provider.ts
+++ b/src/core/llm-providers/anthropic-provider.ts
@@ -93,6 +93,51 @@ export class AnthropicProvider extends LLMProvider {
     }
   }
 
+  /**
+   * Placeholder for critique operation
+   */
+  async critique(
+    symbolId: string,
+    target: Record<string, any>
+  ): Promise<LLMResponse[]> {
+    console.warn('Anthropic critique not fully implemented; returning placeholder');
+    return [
+      {
+        content: 'Critique operation not supported yet',
+        reasoning: 'Anthropic provider lacks critique endpoint',
+        confidence: 0,
+        metadata: { symbolId, target, unsupported: true }
+      }
+    ];
+  }
+
+  /**
+   * Placeholder for link analysis
+   */
+  async link(
+    symbolA: string,
+    symbolB: string,
+    relationSpec: string
+  ): Promise<{ relation: string; confidence: number }[]> {
+    console.warn('Anthropic link not fully implemented; returning placeholder');
+    return [
+      {
+        relation: relationSpec,
+        confidence: 0
+      }
+    ];
+  }
+
+  /**
+   * Placeholder for embedding generation
+   */
+  async embed(payload: any): Promise<number[]> {
+    console.warn('Anthropic embed not fully implemented; returning placeholder vector');
+    const text = JSON.stringify(payload);
+    const hash = this.simpleHash(text);
+    return Array(256).fill(0).map((_, i) => Math.sin(hash + i) * 0.5);
+  }
+
   private buildSystemPrompt(systemPrompt: string | undefined, context: SymbolicContext): string {
     const basePrompt = systemPrompt || 'You are Claude, an AI assistant operating within a recursive symbolic thinking system called ΞKernel.';
     
@@ -160,5 +205,15 @@ You are not just generating text - you are contributing to a living symbolic rea
       case 'stop_sequence': return 0.8;
       default: return 0.6;
     }
+  }
+
+  private simpleHash(str: string): number {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      const char = str.charCodeAt(i);
+      hash = ((hash << 5) - hash) + char;
+      hash |= 0;
+    }
+    return Math.abs(hash);
   }
 }


### PR DESCRIPTION
## Summary
- stub critique, link, and embed methods in `src/core/llm-providers/anthropic-provider.ts`
- log warnings for unsupported operations
- add simple hash helper for placeholder embeddings

## Testing
- `npm test` (fails: rejected path traversal attempts, cache issues)
- `npm run lint` (fails: ESLint couldn't find config "@typescript-eslint/recommended")

------
https://chatgpt.com/codex/tasks/task_e_68c4a3039f24832b8c1ce4a3aa4ccc9a

## Summary by Sourcery

Add placeholder implementations for extended Anthropic operations in AnthropicProvider

New Features:
- Stub the critique method to return placeholder response with warning
- Stub the link method to return placeholder relation with warning
- Stub the embed method to return a synthetic embedding vector with warning

Enhancements:
- Introduce simpleHash helper for generating placeholder embeddings