### PR TITLE
feat(core): add planner and auditor for subgoal control

### DIFF
--- a/src/core/auditor.ts
+++ b/src/core/auditor.ts
@@ -1,0 +1,22 @@
+/**
+ * Auditor module - validates LLM responses for completion
+ */
+
+import type { LLMResponse } from './xi-kernel';
+
+export interface AuditResult {
+  approved: boolean;
+  complete: boolean;
+}
+
+export interface Auditor {
+  audit(response: LLMResponse): AuditResult;
+}
+
+export class CompletionAuditor implements Auditor {
+  audit(response: LLMResponse): AuditResult {
+    const complete = response.meta?.complete === true;
+    return { approved: true, complete };
+  }
+}
+

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -10,6 +10,8 @@ export * from './kernel-factory';
 export * from './meta-architecture';
 export * from './self-analyzer';
 export * from './self-upgrade-engine';
+export * from './planner';
+export * from './auditor';
 export * from './xi-kernel';
 export * from './xi-llm-agent';
 export * from './xi-symbol';

--- a/src/core/llm-providers/clean-openrouter-port.ts
+++ b/src/core/llm-providers/clean-openrouter-port.ts
@@ -100,6 +100,7 @@ Respond clearly and concisely. Your output becomes part of a persistent knowledg
         model: data.model,
         cost: this.calculateCost(data.usage),
         timestamp: new Date(),
+        meta: {},
         metadata: {
           requestId: data.id,
           symbolId,

--- a/src/core/llm-providers/openrouter-port.ts
+++ b/src/core/llm-providers/openrouter-port.ts
@@ -89,6 +89,7 @@ export class OpenRouterPort implements LLMPort {
         model: response.model,
         cost: this.calculateCost(response.usage, response.model),
         timestamp: new Date(),
+        meta: {},
         metadata: {
           requestId: response.id,
           finishReason: response.choices[0]?.finish_reason,

--- a/src/core/llm-providers/truly-free-openrouter-port.ts
+++ b/src/core/llm-providers/truly-free-openrouter-port.ts
@@ -98,6 +98,7 @@ Respond clearly and thoughtfully. Your output becomes part of a persistent knowl
         model: data.model,
         cost: this.calculateTrueCost(data.usage, data.model), // FIXED COST CALCULATION
         timestamp: new Date(),
+        meta: {},
         metadata: {
           requestId: data.id,
           symbolId,

--- a/src/core/planner.ts
+++ b/src/core/planner.ts
@@ -1,0 +1,28 @@
+/**
+ * Planner module - proposes subgoals for ΞKernel evaluation
+ */
+
+import type { LLMSpec, Symbol, ΞGraph } from './xi-kernel';
+
+export interface PlanningContext {
+  goal: Symbol;
+  graph: ΞGraph;
+  step: number;
+  maxSteps: number;
+}
+
+export interface Planner {
+  propose(ctx: PlanningContext): LLMSpec;
+}
+
+export class DefaultPlanner implements Planner {
+  propose({ goal, step, maxSteps }: PlanningContext): LLMSpec {
+    return {
+      symbolId: `${goal.id}_step_${step}`,
+      task: `Step ${step} toward goal: ${JSON.stringify(goal.payload)}`,
+      context: { step, maxSteps },
+      constraints: { maxTokens: 500, temperature: 0.7 }
+    };
+  }
+}
+

--- a/src/core/xi-kernel.ts
+++ b/src/core/xi-kernel.ts
@@ -6,6 +6,8 @@
  */
 
 import { ΞSymbol, ΞPayload, ΞMetadata } from './xi-symbol';
+import { Planner, DefaultPlanner } from './planner';
+import { Auditor, CompletionAuditor } from './auditor';
 
 // === DATA STRUCTURES ===
 
@@ -55,6 +57,7 @@ export interface LLMResponse {
   seed?: number;
   cost?: number;
   timestamp: Date;
+  meta?: Record<string, any>;
 }
 
 export interface LLMDelta {
@@ -199,7 +202,10 @@ export class MockLLMPort implements LLMPort {
       model: 'mock-gpt-4',
       seed: Math.floor(Math.random() * 10000),
       cost: 0.003,
-      timestamp: new Date()
+      timestamp: new Date(),
+      meta: {
+        complete: spec.context?.step >= spec.context?.maxSteps
+      }
     };
   }
 
@@ -237,9 +243,15 @@ export class ΞKernel {
   private graph: ΞGraph;
   private invariantEnforcer: InvariantEnforcer;
   private llmPort: LLMPort;
+  private planner: Planner;
+  private auditor: Auditor;
   private vectorStore: Map<string, number[]> = new Map();
 
-  constructor(llmPort: LLMPort = new MockLLMPort()) {
+  constructor(
+    llmPort: LLMPort = new MockLLMPort(),
+    planner: Planner = new DefaultPlanner(),
+    auditor: Auditor = new CompletionAuditor()
+  ) {
     this.graph = {
       symbols: new Map(),
       edges: new Map(),
@@ -249,7 +261,9 @@ export class ΞKernel {
 
     this.invariantEnforcer = new InvariantEnforcer();
     this.llmPort = llmPort;
-    
+    this.planner = planner;
+    this.auditor = auditor;
+
     this.initializeCoreInvariants();
   }
 
@@ -503,27 +517,38 @@ export class ΞKernel {
   }> {
     let steps = 0;
     const goal = this.getSymbol(goalId);
-    
+
     if (!goal) {
       throw new Error(`Goal symbol ${goalId} not found`);
     }
 
     while (steps < maxSteps) {
       steps++;
-      
-      // Pick next action (simplified planner)
-      const spec: LLMSpec = {
-        symbolId: goalId,
-        task: `Step ${steps} toward goal: ${JSON.stringify(goal.payload)}`,
-        context: { step: steps, maxSteps },
-        constraints: { maxTokens: 500, temperature: 0.7 }
-      };
 
-      // Execute through ports
-      const response = await this.prompt(`${goalId}_step_${steps}`, spec);
-      
-      // Check if goal is satisfied (simplified)
-      if (response.payload && response.payload.toString().includes('COMPLETE')) {
+      const plan = this.planner.propose({ goal, graph: this.graph, step: steps, maxSteps });
+
+      const response = await this.llmPort.prompt(plan.symbolId, plan);
+
+      const audit = this.auditor.audit(response);
+
+      if (audit.approved) {
+        const symbol = this.createSymbol(plan.symbolId, 'llm_generated', response.payload, {
+          model: response.model,
+          promptHash: this.hashSpec(plan),
+          seed: response.seed,
+          timestamp: response.timestamp.toISOString(),
+          cost: response.cost,
+          tokensUsed: response.tokensUsed,
+          kernelWritten: true,
+          justification: response.justification,
+          confidence: response.confidence,
+          task: plan.task,
+          ...(response.meta || {})
+        });
+        await this.syncToVector(symbol);
+      }
+
+      if (audit.complete) {
         break;
       }
     }

--- a/tests/unit/xi-kernel-planner-auditor.test.ts
+++ b/tests/unit/xi-kernel-planner-auditor.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { ΞKernel, MockLLMPort } from '../../src/core/xi-kernel';
+
+// Ensure planner selects subgoals and auditor validates completion
+
+describe('Planner and Auditor integration', () => {
+  it('stops when auditor marks completion', async () => {
+    const kernel = new ΞKernel(new MockLLMPort());
+    (kernel as any).createSymbol('goal', 'goal', { task: 'test' }, {
+      model: 'mock',
+      promptHash: 'hash',
+      timestamp: new Date().toISOString(),
+      kernelWritten: true
+    });
+    const result = await kernel.evaluate('goal', 3);
+    const final = kernel.getSymbol('goal_step_3');
+    expect(result.steps).toBe(3);
+    expect(final?.meta.complete).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Planner module to propose step-wise LLMSpecs
- introduce Auditor module to validate responses via completion flags
- integrate planner selection and auditor approval in kernel evaluation loop

## Testing
- `npm test` *(fails: markdown loader tests)*
- `npm run lint` *(fails: ESLint config missing)*

```json
{
  "route":{"layers":["R","C∞","L","P","Δ"],"CPLO":true,"θ":0.72,"mode":"Deep","lens":"Systems"},
  "invariants":[
    {"id":"INV-1","type":"DesignRule","stmt":"Planner proposals include step and maxSteps context","TTL":"14d"},
    {"id":"INV-2","type":"InterfaceSpec","stmt":"Auditor marks completion via response.meta.complete"}
  ],
  "Δ":{"coherence":false},
  "fail_codes":[],
  "μ":"stable",
  "nnr":{"guard":"variance-cut≤0.7","score":"0.5","verdict":"pass"},
  "next":[
    {"type":"artifact","action":"extend planner heuristics","cost":"S","owner":"Koriel-ASI"}
  ],
  "DFT-log":[]
}
```

------
https://chatgpt.com/codex/tasks/task_e_68c4a30989dc832bbbf2a3472a8aa095

## Summary by Sourcery

Add a planning and auditing workflow to ΞKernel by introducing Planner and Auditor modules, enriching LLM responses with metadata, and orchestrating stepwise subgoal proposals and completion checks in the evaluation loop.

New Features:
- Add Planner interface and DefaultPlanner to propose stepwise LLMSpecs
- Add Auditor interface and CompletionAuditor to validate LLM responses via completion flags

Enhancements:
- Extend LLMResponse with a meta field and update LLM provider ports to populate it
- Integrate planner.propose and auditor.audit into ΞKernel’s evaluation loop for structured subgoal execution
- Export planner and auditor modules from the core index

Tests:
- Add unit tests for the planner and auditor integration in XiKernel